### PR TITLE
Use Promise.try where possible

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -184,8 +184,8 @@ Connection.prototype.processOutcomeMessage = function(message) {
  */
 Connection.prototype.processIncomeMessage = function(message) {
   var connection = this;
-  return Promise.resolve(message)
-    .then(function(message) {
+  return Promise
+    .try(function() {
       var sessionId = message['session_id'];
       if (sessionId) {
         if (connection.hasSession(sessionId)) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -93,8 +93,8 @@ Plugin.prototype.processOutcomeMessage = function(message) {
  */
 Plugin.prototype.processIncomeMessage = function(message) {
   var plugin = this;
-  return Promise.resolve(message)
-    .then(function(message) {
+  return Promise
+    .try(function() {
       var janusMessage = message['janus'];
       if ('detached' === janusMessage) {
         return plugin._onDetached(message);


### PR DESCRIPTION
In some places we used `Promise.resolve(message)` to exclude usages of `new Promise`. Now we can use `Promise.try`