### PR TITLE
Plugin method names

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,19 +275,19 @@ The library is available for Node and Browser environment. In Browser it is decl
 ### AudiobridgePlugin
   It corresponds to 'janus.plugin.audiobridge'. Extends `MediaPlugin`. More thorough details to methods params below can be found at @see https://janus.conf.meetecho.com/docs/janus__audiobridge_8c.html#details. Additional methods to `MediaPlugin` are:
 
- * `plugin.createRoom(roomId, [options])`
+ * `plugin.create(roomId, [options])`
 
     Requests to create an audio room. Returns a promise that is resolved when the room is created.
     * `roomId` int
     * `options` Object. see JSDocu.
 
- * `plugin.destroyRoom(roomId, [options])`
+ * `plugin.destroy(roomId, [options])`
 
     Requests to destroy the audio room. Returns a promise that is resolved when the room is destroyed.
     * `roomId` int
     * `options` Object. see JSDocu.
 
- * `plugin.listRooms()`
+ * `plugin.list()`
 
     Requests the list of current rooms. Returns a promise that is resolved with the list.
 
@@ -296,17 +296,17 @@ The library is available for Node and Browser environment. In Browser it is decl
     Requests the room's list of participants. Returns a promise that is resolved with the list.
     * `roomId` int
 
- * `plugin.joinRoom(roomId, [options])`
+ * `plugin.join(roomId, [options])`
 
     Requests to join the audio room. Returns a promise that is resolved when the room is joined.
     * `roomId` int
     * `options` Object. see JSDocu.
 
- * `plugin.leaveRoom()`
+ * `plugin.leave()`
 
     Requests to leave the current room. Returns a promise that is resolved when the room is left.
 
- * `plugin.changeRoom(roomId, [options])`
+ * `plugin.change(roomId, [options])`
 
     Requests to change the room. Returns a promise that is resolved when the room is changed.
     * `roomId` int

--- a/examples/browser/audiobridge.html
+++ b/examples/browser/audiobridge.html
@@ -30,15 +30,15 @@
             plugin.on('pc:addstream', function(event) {
               Janus.webrtc.browserShim.attachMediaStream(document.getElementById('audio'), event.stream);
             });
-            return plugin.createRoom(666)
+            return plugin.create(666)
               .then(function() {
-                return plugin.listRooms();
+                return plugin.list();
               })
               .then(function(rooms) {
                 console.log('Audiobridge rooms', rooms);
               })
               .then(function() {
-                return plugin.connectRoom(666);
+                return plugin.connect(666);
               })
               .then(function() {
                 return plugin.listParticipants(666);
@@ -50,13 +50,13 @@
                 return plugin.startStream({muted: false});
               })
               .then(function() {
-                return plugin.createRoom(1234);
+                return plugin.create(1234);
               })
               .then(function() {
-                return plugin.connectRoom(1234);
+                return plugin.connect(1234);
               })
               .then(function() {
-                return plugin.destroyRoom(666);
+                return plugin.destroy(666);
               });
           })
           .catch(function(error) {

--- a/src/webrtc/plugin/audiobridge-plugin.js
+++ b/src/webrtc/plugin/audiobridge-plugin.js
@@ -28,7 +28,7 @@ Plugin.register(AudiobridgePlugin.NAME, AudiobridgePlugin);
  * @param {string} [options.record_file]
  * @return {Promise}
  */
-AudiobridgePlugin.prototype.createRoom = function(roomId, options) {
+AudiobridgePlugin.prototype.create = function(roomId, options) {
   return this._create(Helpers.extend({room: roomId}, options));
 };
 
@@ -39,7 +39,7 @@ AudiobridgePlugin.prototype.createRoom = function(roomId, options) {
  * @param {boolean} [options.permanent]
  * @return {Promise}
  */
-AudiobridgePlugin.prototype.destroyRoom = function(roomId, options) {
+AudiobridgePlugin.prototype.destroy = function(roomId, options) {
   return this._destroy(Helpers.extend({room: roomId}, options))
     .then(function() {
       if (roomId == this._currentRoomId) {
@@ -51,7 +51,7 @@ AudiobridgePlugin.prototype.destroyRoom = function(roomId, options) {
 /**
  * @return {Promise}
  */
-AudiobridgePlugin.prototype.listRooms = function() {
+AudiobridgePlugin.prototype.list = function() {
   return this._list();
 };
 
@@ -80,7 +80,7 @@ AudiobridgePlugin.prototype.listParticipants = function(roomId) {
  * @param {int} [options.quality]
  * @return {Promise}
  */
-AudiobridgePlugin.prototype.joinRoom = function(roomId, options) {
+AudiobridgePlugin.prototype.join = function(roomId, options) {
   var body = Helpers.extend({
     request: 'join',
     room: roomId
@@ -94,7 +94,7 @@ AudiobridgePlugin.prototype.joinRoom = function(roomId, options) {
 /**
  * @return {Promise}
  */
-AudiobridgePlugin.prototype.leaveRoom = function() {
+AudiobridgePlugin.prototype.leave = function() {
   return this.sendWithTransaction({body: {request: 'leave'}})
     .then(function() {
       this._currentRoomId = null;
@@ -111,7 +111,7 @@ AudiobridgePlugin.prototype.leaveRoom = function() {
  * @param {int} [options.quality]
  * @return {Promise}
  */
-AudiobridgePlugin.prototype.changeRoom = function(roomId, options) {
+AudiobridgePlugin.prototype.change = function(roomId, options) {
   var body = Helpers.extend({
     request: 'changeroom',
     room: roomId
@@ -131,14 +131,14 @@ AudiobridgePlugin.prototype.changeRoom = function(roomId, options) {
  * @param {int} [options.quality]
  * @return {Promise}
  */
-AudiobridgePlugin.prototype.connectRoom = function(roomId, options) {
+AudiobridgePlugin.prototype.connect = function(roomId, options) {
   if (roomId == this._currentRoomId) {
     return Promise.resolve();
   }
   if (this._currentRoomId) {
-    return this.changeRoom(roomId, options);
+    return this.change(roomId, options);
   }
-  return this.joinRoom(roomId, options);
+  return this.join(roomId, options);
 };
 
 /**


### PR DESCRIPTION
Shall we shorten them? Lets take for example Audiobridge. Now we have
```js
AudiobridgePlugin.prototype.joinRoom(roomId, options)
```

Shall we have instead
```js
AudiobridgePlugin.prototype.join(roomId, options)
```
@zazabe @tomaszdurka your thoughts?