### PR TITLE
Responses in plugin methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,11 +292,11 @@ The library is available for Node and Browser environment. In Browser it is decl
 
  * `plugin.list()`
 
-    Requests the list of current rooms. Returns a promise that is resolved with the list.
+    Requests the list of current rooms. Returns a promise that is resolved with the plugin response.
 
  * `plugin.listParticipants(roomId)`
 
-    Requests the room's list of participants. Returns a promise that is resolved with the list.
+    Requests the room's list of participants. Returns a promise that is resolved with the plugin response.
     * `roomId` int
 
  * `plugin.join(roomId, [options])`
@@ -353,7 +353,7 @@ The library is available for Node and Browser environment. In Browser it is decl
 
  * `plugin.list()`
 
-    Requests the list of current streams. Returns a promise that is resolved with the list.
+    Requests the list of current streams. Returns a promise that is resolved with the plugin response.
 
  * `plugin.watch(mountpointId, [options])`
 

--- a/src/plugin-response.js
+++ b/src/plugin-response.js
@@ -10,14 +10,17 @@ function PluginResponse(response) {
  * @returns {*}
  */
 PluginResponse.prototype.getError = function() {
-  return this.getData()['error'] || this.get('error');
+  return this.getData('error') || this.get('error');
 };
 
 /**
+ * @param {..String} [name]
  * @returns {Object}
  */
-PluginResponse.prototype.getData = function() {
-  return this.get('plugindata', 'data');
+PluginResponse.prototype.getData = function(name) {
+  var names = Array.prototype.slice.call(arguments);
+  names.unshift('plugindata', 'data');
+  return this.get.apply(this, names);
 };
 
 /**

--- a/src/plugin-response.js
+++ b/src/plugin-response.js
@@ -1,0 +1,43 @@
+/**
+ * @param {Object} response
+ * @constructor
+ */
+function PluginResponse(response) {
+  this._response = response;
+}
+
+/**
+ * @returns {*}
+ */
+PluginResponse.prototype.getError = function() {
+  return this.get('error') || this.getData()['error'];
+};
+
+/**
+ * @returns {Object}
+ */
+PluginResponse.prototype.getData = function() {
+  return this.get('plugindata', 'data');
+};
+
+/**
+ * @param {..String} name
+ * @returns {*}
+ */
+PluginResponse.prototype.get = function(name) {
+  var names = Array.prototype.slice.call(arguments, 1);
+  var result = this._response[name];
+
+  for (var i = 0; i < names.length; i++) {
+    name = names[i];
+    if (result) {
+      result = result[name];
+    } else {
+      break;
+    }
+  }
+
+  return result || null;
+};
+
+module.exports = PluginResponse;

--- a/src/plugin-response.js
+++ b/src/plugin-response.js
@@ -10,7 +10,7 @@ function PluginResponse(response) {
  * @returns {*}
  */
 PluginResponse.prototype.getError = function() {
-  return this.get('error') || this.getData()['error'];
+  return this.getData()['error'] || this.get('error');
 };
 
 /**

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -4,6 +4,7 @@ var TEventEmitter = require('./traits/t-event-emitter');
 var TTransactionGateway = require('./traits/t-transaction-gateway');
 var JanusError = require('./error');
 var Transaction = require('./transaction');
+var PluginResponse = require('./plugin-response');
 
 /**
  * @param {Session} session
@@ -158,12 +159,13 @@ Plugin.prototype.toString = function() {
 /**
  * @param {Object} options
  * @returns {Promise}
- * @fulfilled {*}
+ * @fulfilled {PluginResponse}
  */
 Plugin.prototype.sendWithTransaction = function(options) {
   var transactionId = Transaction.generateRandomId();
   var transaction = new Transaction(transactionId, function(response) {
-    var errorMessage = response['plugindata']['data']['error'];
+    response = new PluginResponse(response);
+    var errorMessage = response.getError();
     if (!errorMessage) {
       return Promise.resolve(response);
     }

--- a/src/webrtc/media-audio-plugin.js
+++ b/src/webrtc/media-audio-plugin.js
@@ -1,5 +1,6 @@
 var Promise = require('bluebird');
 var Helpers = require('../helpers');
+var PluginResponse = require('../plugin-response');
 var MediaEntityPlugin = require('./media-entity-plugin');
 
 function MediaAudioPlugin() {
@@ -15,7 +16,7 @@ Helpers.inherits(MediaAudioPlugin, MediaEntityPlugin);
  * @param {string|number} id
  * @param {Object} options
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaAudioPlugin.prototype._destroy = function(id, options) {
   return MediaAudioPlugin.super_.prototype._destroy.call(this, options)
@@ -31,7 +32,7 @@ MediaAudioPlugin.prototype._destroy = function(id, options) {
  * @param {string|number} id
  * @param {Object} options
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaAudioPlugin.prototype._join = function(id, options) {
   var body = Helpers.extend({request: 'join'}, options);
@@ -44,7 +45,7 @@ MediaAudioPlugin.prototype._join = function(id, options) {
 
 /**
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaAudioPlugin.prototype.leave = function() {
   return this.sendWithTransaction({body: {request: 'leave'}})
@@ -58,7 +59,7 @@ MediaAudioPlugin.prototype.leave = function() {
  * @param {string|number} id
  * @param {Object} [options]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaAudioPlugin.prototype._change = function(id, options) {
   var body = Helpers.extend({request: 'changeroom'}, options);
@@ -73,11 +74,11 @@ MediaAudioPlugin.prototype._change = function(id, options) {
  * @param {string|number} id
  * @param {Object} [options]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaAudioPlugin.prototype._connect = function(id, options) {
   if (id == this._currentRoomId) {
-    return Promise.resolve();
+    return Promise.resolve(new PluginResponse({}));
   }
   if (this._currentRoomId) {
     return this._change(id, options);
@@ -87,7 +88,7 @@ MediaAudioPlugin.prototype._connect = function(id, options) {
 
 /**
  * @returns {Promise}
- * @fulfilled {Array} list
+ * @fulfilled {PluginResponse} response
  */
 MediaAudioPlugin.prototype.list = function() {
   return this._list();
@@ -99,7 +100,7 @@ MediaAudioPlugin.prototype.list = function() {
  * @param {number} [options.quality]
  * @param {RTCSessionDescription} [jsep]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaAudioPlugin.prototype.configure = function(options, jsep) {
   var body = Helpers.extend({
@@ -149,7 +150,7 @@ MediaAudioPlugin.prototype.startMediaStreaming = function(offerOptions, configur
 MediaAudioPlugin.prototype.sendSDP = function(jsep, configureOptions) {
   return this.configure(configureOptions, jsep)
     .then(function(response) {
-      var jsep = response['jsep'];
+      var jsep = response.get('jsep');
       if (jsep) {
         this.setRemoteSDP(jsep);
         return jsep;
@@ -161,14 +162,11 @@ MediaAudioPlugin.prototype.sendSDP = function(jsep, configureOptions) {
 /**
  * @param {Object} options
  * @returns {Promise}
- * @fulfilled {Array} list
+ * @fulfilled {PluginResponse} list
  */
 MediaAudioPlugin.prototype._listParticipants = function(options) {
   var body = Helpers.extend({request: 'listparticipants'}, options);
-  return this.sendWithTransaction({body: body})
-    .then(function(response) {
-      return response['plugindata']['data']['participants'];
-    });
+  return this.sendWithTransaction({body: body});
 };
 
 module.exports = MediaAudioPlugin;

--- a/src/webrtc/media-entity-plugin.js
+++ b/src/webrtc/media-entity-plugin.js
@@ -10,7 +10,7 @@ Helpers.inherits(MediaEntityPlugin, MediaPlugin);
 /**
  * @param {Object} options
  * @returns {Promise}
- * @fulfilled {Object} response - response['plugindata']['data']
+ * @fulfilled {PluginResponse} response
  */
 MediaEntityPlugin.prototype._create = function(options) {
   var body = Helpers.extend({request: 'create'}, options);
@@ -21,16 +21,13 @@ MediaEntityPlugin.prototype._create = function(options) {
       } else {
         throw error;
       }
-    })
-    .then(function(response) {
-      return response['plugindata']['data'];
     });
 };
 
 /**
  * @param {Object} options
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaEntityPlugin.prototype._destroy = function(options) {
   var body = Helpers.extend({request: 'destroy'}, options);
@@ -40,14 +37,11 @@ MediaEntityPlugin.prototype._destroy = function(options) {
 /**
  * @param {Object} [options]
  * @returns {Promise}
- * @fulfilled {Array} response - response['plugindata']['data']['list']
+ * @fulfilled {PluginResponse} response
  */
 MediaEntityPlugin.prototype._list = function(options) {
   var body = Helpers.extend({request: 'list'}, options);
-  return this.sendWithTransaction({body: body})
-    .then(function(response) {
-      return response['plugindata']['data']['list'];
-    });
+  return this.sendWithTransaction({body: body});
 };
 
 module.exports = MediaEntityPlugin;

--- a/src/webrtc/media-stream-plugin.js
+++ b/src/webrtc/media-stream-plugin.js
@@ -1,5 +1,6 @@
 var Promise = require('bluebird');
 var Helpers = require('../helpers');
+var PluginResponse = require('../plugin-response');
 var MediaEntityPlugin = require('./media-entity-plugin');
 
 function MediaStreamPlugin() {
@@ -15,7 +16,7 @@ Helpers.inherits(MediaStreamPlugin, MediaEntityPlugin);
  * @param {string|number} id
  * @param {Object} options
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaStreamPlugin.prototype._create = function(id, options) {
   options = Helpers.extend({id: id}, options);
@@ -32,7 +33,7 @@ MediaStreamPlugin.prototype._create = function(id, options) {
  * @param {string|number} id
  * @param {Object} options
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaStreamPlugin.prototype._destroy = function(id, options) {
   options = Helpers.extend({id: id}, options);
@@ -50,14 +51,14 @@ MediaStreamPlugin.prototype._destroy = function(id, options) {
  * @param {Object} [watchOptions]
  * @param {Object} [answerOptions]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaStreamPlugin.prototype._watch = function(id, watchOptions, answerOptions) {
   var plugin = this;
   var body = Helpers.extend({request: 'watch', id: id}, watchOptions);
   return this.sendWithTransaction({body: body})
     .then(function(response) {
-      var jsep = response['jsep'];
+      var jsep = response.get('jsep');
       if (!jsep || 'offer' != jsep['type']) {
         throw new Error('Expect offer response on watch request')
       }
@@ -69,7 +70,7 @@ MediaStreamPlugin.prototype._watch = function(id, watchOptions, answerOptions) {
 /**
  * @param {RTCSessionDescription} [jsep]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaStreamPlugin.prototype._start = function(jsep) {
   var message = {body: {request: 'start'}};
@@ -81,7 +82,7 @@ MediaStreamPlugin.prototype._start = function(jsep) {
 
 /**
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaStreamPlugin.prototype._stop = function() {
   return this.sendWithTransaction({body: {request: 'stop'}})
@@ -93,7 +94,7 @@ MediaStreamPlugin.prototype._stop = function() {
 
 /**
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaStreamPlugin.prototype._pause = function() {
   return this.sendWithTransaction({body: {request: 'pause'}});
@@ -103,7 +104,7 @@ MediaStreamPlugin.prototype._pause = function() {
  * @param {string|number} id
  * @param {Object} [options]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaStreamPlugin.prototype._switch = function(id, options) {
   var body = Helpers.extend({
@@ -122,11 +123,11 @@ MediaStreamPlugin.prototype._switch = function(id, options) {
  * @param {Object} [watchOptions]
  * @param {Object} [answerOptions]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaStreamPlugin.prototype.connect = function(id, watchOptions, answerOptions) {
   if (id == this._currentMountpointId) {
-    return Promise.resolve();
+    return Promise.resolve(new PluginResponse({}));
   }
   if (this._currentMountpointId) {
     return this._switch(id, watchOptions);
@@ -138,7 +139,7 @@ MediaStreamPlugin.prototype.connect = function(id, watchOptions, answerOptions) 
  * @param {RTCSessionDescription} jsep
  * @param {RTCAnswerOptions} [answerOptions]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 MediaStreamPlugin.prototype._startMediaStreaming = function(jsep, answerOptions) {
   var self = this;

--- a/src/webrtc/plugin/audiobridge-plugin.js
+++ b/src/webrtc/plugin/audiobridge-plugin.js
@@ -23,7 +23,7 @@ Plugin.register(AudiobridgePlugin.NAME, AudiobridgePlugin);
  * @param {boolean} [options.record]
  * @param {string} [options.record_file]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 AudiobridgePlugin.prototype.create = function(roomId, options) {
   return this._create(Helpers.extend({room: roomId}, options));
@@ -35,7 +35,7 @@ AudiobridgePlugin.prototype.create = function(roomId, options) {
  * @param {string} [options.secret]
  * @param {boolean} [options.permanent]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 AudiobridgePlugin.prototype.destroy = function(roomId, options) {
   return this._destroy(roomId, Helpers.extend({room: roomId}, options));
@@ -50,7 +50,7 @@ AudiobridgePlugin.prototype.destroy = function(roomId, options) {
  * @param {boolean} [options.muted]
  * @param {number} [options.quality]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 AudiobridgePlugin.prototype.join = function(roomId, options) {
   options = Helpers.extend({room: roomId}, options);
@@ -66,7 +66,7 @@ AudiobridgePlugin.prototype.join = function(roomId, options) {
  * @param {boolean} [options.muted]
  * @param {number} [options.quality]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 AudiobridgePlugin.prototype.change = function(roomId, options) {
   options = Helpers.extend({room: roomId}, options);
@@ -81,7 +81,7 @@ AudiobridgePlugin.prototype.change = function(roomId, options) {
  * @param {boolean} [options.muted]
  * @param {number} [options.quality]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 AudiobridgePlugin.prototype.connect = function(roomId, options) {
   options = Helpers.extend({room: roomId}, options);

--- a/src/webrtc/plugin/audioroom-plugin.js
+++ b/src/webrtc/plugin/audioroom-plugin.js
@@ -16,7 +16,7 @@ Plugin.register(AudioroomPlugin.NAME, AudioroomPlugin);
  * @param {string} [options.secret]
  * @param {boolean} [options.permanent]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 AudioroomPlugin.prototype.destroy = function(id, options) {
   return this._destroy(id, Helpers.extend({id: id}, options));
@@ -30,7 +30,7 @@ AudioroomPlugin.prototype.destroy = function(id, options) {
  * @param {boolean} [options.muted]
  * @param {number} [options.quality]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 AudioroomPlugin.prototype.join = function(id, options) {
   options = Helpers.extend({id: id}, options);
@@ -41,7 +41,7 @@ AudioroomPlugin.prototype.join = function(id, options) {
  * @param {string} id
  * @param {Object} [options] {@link join}
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 AudioroomPlugin.prototype.change = function(id, options) {
   options = Helpers.extend({id: id}, options);
@@ -52,7 +52,7 @@ AudioroomPlugin.prototype.change = function(id, options) {
  * @param {string} id
  * @param {Object} [options] {@link join}
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 AudioroomPlugin.prototype.connect = function(id, options) {
   options = Helpers.extend({id: id}, options);

--- a/src/webrtc/plugin/rtpbroadcast-plugin.js
+++ b/src/webrtc/plugin/rtpbroadcast-plugin.js
@@ -25,7 +25,7 @@ Plugin.register(RtpbroadcastPlugin.NAME, RtpbroadcastPlugin);
  * @param {string} [options.whitelist]
  * @param {StreamParams} [options.streams]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 RtpbroadcastPlugin.prototype.create = function(id, options) {
   return this._create(id, options);
@@ -34,7 +34,7 @@ RtpbroadcastPlugin.prototype.create = function(id, options) {
 /**
  * @param {string} id
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 RtpbroadcastPlugin.prototype.destroy = function(id) {
   return this._destroy(id);
@@ -53,7 +53,7 @@ RtpbroadcastPlugin.prototype.list = function(id) {
  * @param {string} id
  * @param {Object} [answerOptions] {@link createAnswer}
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 RtpbroadcastPlugin.prototype.watch = function(id, answerOptions) {
   return this._watch(id, null, answerOptions);
@@ -63,7 +63,7 @@ RtpbroadcastPlugin.prototype.watch = function(id, answerOptions) {
  * @param {string} id
  * @param {Array} streams
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 RtpbroadcastPlugin.prototype.watchUDP = function(id, streams) {
   return this.sendWithTransaction({body: {request: 'watch-udp', id: id, streams: streams}});
@@ -71,7 +71,7 @@ RtpbroadcastPlugin.prototype.watchUDP = function(id, streams) {
 
 /**
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 RtpbroadcastPlugin.prototype.start = function() {
   return this._start();
@@ -79,7 +79,7 @@ RtpbroadcastPlugin.prototype.start = function() {
 
 /**
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 RtpbroadcastPlugin.prototype.stop = function() {
   return this._stop();
@@ -87,7 +87,7 @@ RtpbroadcastPlugin.prototype.stop = function() {
 
 /**
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 RtpbroadcastPlugin.prototype.pause = function() {
   return this._pause();
@@ -96,7 +96,7 @@ RtpbroadcastPlugin.prototype.pause = function() {
 /**
  * @param {string} id
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 RtpbroadcastPlugin.prototype.switch = function(id) {
   return this._switch(id);
@@ -105,7 +105,7 @@ RtpbroadcastPlugin.prototype.switch = function(id) {
 /**
  * @param {number} index
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 RtpbroadcastPlugin.prototype.switchSource = function(index) {
   return this.sendWithTransaction({body: {request: 'switch-source', index: index}});
@@ -114,7 +114,7 @@ RtpbroadcastPlugin.prototype.switchSource = function(index) {
 /**
  * @param {boolean} enabled
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 RtpbroadcastPlugin.prototype.superuser = function(enabled) {
   return this.sendWithTransaction({body: {request: 'superuser', enabled: enabled}});

--- a/src/webrtc/plugin/streaming-plugin.js
+++ b/src/webrtc/plugin/streaming-plugin.js
@@ -36,7 +36,7 @@ Plugin.register(StreamingPlugin.NAME, StreamingPlugin);
  * @param {boolean} [options.videobufferkf]
  * @param {string} [options.url]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 StreamingPlugin.prototype.create = function(id, options) {
   return this._create(id, options);
@@ -48,7 +48,7 @@ StreamingPlugin.prototype.create = function(id, options) {
  * @param {string} [options.secret]
  * @param {boolean} [options.permanent]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 StreamingPlugin.prototype.destroy = function(id, options) {
   return this._destroy(id, options);
@@ -56,7 +56,7 @@ StreamingPlugin.prototype.destroy = function(id, options) {
 
 /**
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 StreamingPlugin.prototype.list = function() {
   return this._list();
@@ -68,7 +68,7 @@ StreamingPlugin.prototype.list = function() {
  * @param {string} [watchOptions.pin]
  * @param {Object} [answerOptions] {@link createAnswer}
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 StreamingPlugin.prototype.watch = function(id, watchOptions, answerOptions) {
   return this._watch(id, watchOptions, answerOptions);
@@ -77,7 +77,7 @@ StreamingPlugin.prototype.watch = function(id, watchOptions, answerOptions) {
 /**
  * @param {RTCSessionDescription} [jsep]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 StreamingPlugin.prototype.start = function(jsep) {
   return this._start(jsep);
@@ -85,7 +85,7 @@ StreamingPlugin.prototype.start = function(jsep) {
 
 /**
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 StreamingPlugin.prototype.stop = function() {
   return this._stop();
@@ -93,7 +93,7 @@ StreamingPlugin.prototype.stop = function() {
 
 /**
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 StreamingPlugin.prototype.pause = function() {
   return this._pause();
@@ -103,7 +103,7 @@ StreamingPlugin.prototype.pause = function() {
  * @param {number} mountpointId
  * @param {Object} [options] {@link watch}
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 StreamingPlugin.prototype.switch = function(mountpointId, options) {
   return this._switch(mountpointId, options);
@@ -114,7 +114,7 @@ StreamingPlugin.prototype.switch = function(mountpointId, options) {
  * @param {Object} [options]
  * @param {string} [options.secret]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 StreamingPlugin.prototype.enable = function(mountpointId, options) {
   var body = Helpers.extend({
@@ -129,7 +129,7 @@ StreamingPlugin.prototype.enable = function(mountpointId, options) {
  * @param {Object} [options]
  * @param {string} [options.secret]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 StreamingPlugin.prototype.disable = function(mountpointId, options) {
   var body = Helpers.extend({
@@ -152,7 +152,7 @@ StreamingPlugin.prototype.disable = function(mountpointId, options) {
  * @param {string} [options.audio]
  * @param {string} [options.video]
  * @returns {Promise}
- * @fulfilled {Object} response
+ * @fulfilled {PluginResponse} response
  */
 StreamingPlugin.prototype.recording = function(mountpointId, options) {
   var body = Helpers.extend({

--- a/test/integration/audiobridge.js
+++ b/test/integration/audiobridge.js
@@ -49,14 +49,15 @@ describe('Audiobridge tests', function() {
     var roomId = randomRoomId();
     audiobridgePlugin.create(roomId)
       .then(function(response) {
-        assert.equal(response['audiobridge'], 'created');
+        assert.equal(response.getData()['audiobridge'], 'created');
         return audiobridgePlugin.join(roomId);
       })
       .then(function(response) {
-        assert.equal(response['plugindata']['data']['audiobridge'], 'joined');
+        assert.equal(response.getData()['audiobridge'], 'joined');
         return audiobridgePlugin.list();
       })
-      .then(function(rooms) {
+      .then(function(response) {
+        var rooms = response.getData()['list'];
         var createdRoom = jQuery.grep(rooms, function(room) {
           return room.room == roomId;
         });
@@ -74,7 +75,8 @@ describe('Audiobridge tests', function() {
       .then(function() {
         return audiobridgePlugin.listParticipants(roomId);
       })
-      .then(function(participants) {
+      .then(function(response) {
+        var participants = response.getData()['participants'];
         assert.equal(participants.length, 1);
         done();
       });
@@ -94,7 +96,7 @@ describe('Audiobridge tests', function() {
         return audiobridgePlugin.connect(roomId2);
       })
       .then(function(response) {
-        assert.equal(response['plugindata']['data']['audiobridge'], 'roomchanged');
+        assert.equal(response.getData()['audiobridge'], 'roomchanged');
         done();
       });
   });

--- a/test/integration/audiobridge.js
+++ b/test/integration/audiobridge.js
@@ -49,15 +49,15 @@ describe('Audiobridge tests', function() {
     var roomId = randomRoomId();
     audiobridgePlugin.create(roomId)
       .then(function(response) {
-        assert.equal(response.getData()['audiobridge'], 'created');
+        assert.equal(response.getData('audiobridge'), 'created');
         return audiobridgePlugin.join(roomId);
       })
       .then(function(response) {
-        assert.equal(response.getData()['audiobridge'], 'joined');
+        assert.equal(response.getData('audiobridge'), 'joined');
         return audiobridgePlugin.list();
       })
       .then(function(response) {
-        var rooms = response.getData()['list'];
+        var rooms = response.getData('list');
         var createdRoom = jQuery.grep(rooms, function(room) {
           return room.room == roomId;
         });
@@ -76,7 +76,7 @@ describe('Audiobridge tests', function() {
         return audiobridgePlugin.listParticipants(roomId);
       })
       .then(function(response) {
-        var participants = response.getData()['participants'];
+        var participants = response.getData('participants');
         assert.equal(participants.length, 1);
         done();
       });
@@ -96,7 +96,7 @@ describe('Audiobridge tests', function() {
         return audiobridgePlugin.connect(roomId2);
       })
       .then(function(response) {
-        assert.equal(response.getData()['audiobridge'], 'roomchanged');
+        assert.equal(response.getData('audiobridge'), 'roomchanged');
         done();
       });
   });

--- a/test/integration/audioroom.js
+++ b/test/integration/audioroom.js
@@ -49,11 +49,11 @@ describe('Audioroom tests', function() {
     var roomId = randomRoomId();
     audioroomPlugin.connect(roomId)
       .then(function(response) {
-        assert.equal(response.getData()['audioroom'], 'joined');
+        assert.equal(response.getData('audioroom'), 'joined');
         return audioroomPlugin.list();
       })
       .then(function(response) {
-        var rooms = response.getData()['list'];
+        var rooms = response.getData('list');
         var createdRoom = jQuery.grep(rooms, function(room) {
           return room.id == roomId;
         });
@@ -69,7 +69,7 @@ describe('Audioroom tests', function() {
         return audioroomPlugin.listParticipants(roomId);
       })
       .then(function(response) {
-        var participants = response.getData()['participants'];
+        var participants = response.getData('participants');
         assert.equal(participants.length, 1);
         done();
       });
@@ -83,7 +83,7 @@ describe('Audioroom tests', function() {
         return audioroomPlugin.connect(roomId2);
       })
       .then(function(response) {
-        assert.equal(response.getData()['audioroom'], 'roomchanged');
+        assert.equal(response.getData('audioroom'), 'roomchanged');
         done();
       });
   });

--- a/test/integration/audioroom.js
+++ b/test/integration/audioroom.js
@@ -49,10 +49,11 @@ describe('Audioroom tests', function() {
     var roomId = randomRoomId();
     audioroomPlugin.connect(roomId)
       .then(function(response) {
-        assert.equal(response['plugindata']['data']['audioroom'], 'joined');
+        assert.equal(response.getData()['audioroom'], 'joined');
         return audioroomPlugin.list();
       })
-      .then(function(rooms) {
+      .then(function(response) {
+        var rooms = response.getData()['list'];
         var createdRoom = jQuery.grep(rooms, function(room) {
           return room.id == roomId;
         });
@@ -67,7 +68,8 @@ describe('Audioroom tests', function() {
       .then(function() {
         return audioroomPlugin.listParticipants(roomId);
       })
-      .then(function(participants) {
+      .then(function(response) {
+        var participants = response.getData()['participants'];
         assert.equal(participants.length, 1);
         done();
       });
@@ -81,7 +83,7 @@ describe('Audioroom tests', function() {
         return audioroomPlugin.connect(roomId2);
       })
       .then(function(response) {
-        assert.equal(response['plugindata']['data']['audioroom'], 'roomchanged');
+        assert.equal(response.getData()['audioroom'], 'roomchanged');
         done();
       });
   });

--- a/test/integration/rtpbroadcast.js
+++ b/test/integration/rtpbroadcast.js
@@ -66,8 +66,10 @@ describe('Rtpbroadcast tests', function() {
       })
       .then(function(response) {
         var list = response.getData('list');
-        assert.equal(list.length, 1);
-        assert.equal(list[0]['id'], mountpointId);
+        var createdMountpoint = jQuery.grep(list, function(mountpoint) {
+          return mountpoint.id == mountpointId;
+        });
+        assert.equal(createdMountpoint.length, 1);
         return rtpbroadcastPlugin.destroy(mountpointId);
       })
       .then(function(response) {

--- a/test/integration/rtpbroadcast.js
+++ b/test/integration/rtpbroadcast.js
@@ -61,16 +61,17 @@ describe('Rtpbroadcast tests', function() {
     var mountpointId = randomMountpointId();
     rtpbroadcastPlugin.create(mountpointId, mountpointOptions)
       .then(function(response) {
-        assert.equal(response['created'], mountpointOptions['name']);
+        assert.equal(response.getData()['created'], mountpointOptions['name']);
         return rtpbroadcastPlugin.list(mountpointId);
       })
-      .then(function(list) {
+      .then(function(response) {
+        var list = response.getData()['list'];
         assert.equal(list.length, 1);
         assert.equal(list[0]['id'], mountpointId);
         return rtpbroadcastPlugin.destroy(mountpointId);
       })
       .then(function(response) {
-        assert.equal(response['plugindata']['data']['destroyed'], mountpointId);
+        assert.equal(response.getData()['destroyed'], mountpointId);
         done();
       });
   });

--- a/test/integration/rtpbroadcast.js
+++ b/test/integration/rtpbroadcast.js
@@ -61,17 +61,17 @@ describe('Rtpbroadcast tests', function() {
     var mountpointId = randomMountpointId();
     rtpbroadcastPlugin.create(mountpointId, mountpointOptions)
       .then(function(response) {
-        assert.equal(response.getData()['created'], mountpointOptions['name']);
+        assert.equal(response.getData('created'), mountpointOptions['name']);
         return rtpbroadcastPlugin.list(mountpointId);
       })
       .then(function(response) {
-        var list = response.getData()['list'];
+        var list = response.getData('list');
         assert.equal(list.length, 1);
         assert.equal(list[0]['id'], mountpointId);
         return rtpbroadcastPlugin.destroy(mountpointId);
       })
       .then(function(response) {
-        assert.equal(response.getData()['destroyed'], mountpointId);
+        assert.equal(response.getData('destroyed'), mountpointId);
         done();
       });
   });

--- a/test/integration/streaming.js
+++ b/test/integration/streaming.js
@@ -57,11 +57,11 @@ describe('Steraming tests', function() {
     var mountpointId = randomMountpointId();
     streamingPlugin.create(mountpointId, mountpointOptions)
       .then(function(response) {
-        assert.equal(response.getData()['stream']['id'], mountpointId);
+        assert.equal(response.getData('stream', 'id'), mountpointId);
         return streamingPlugin.list();
       })
       .then(function(response) {
-        var list = response.getData()['list'];
+        var list = response.getData('list');
         var createdMountpoint = jQuery.grep(list, function(mountpoint) {
           return mountpoint.id == mountpointId;
         });
@@ -69,7 +69,7 @@ describe('Steraming tests', function() {
         return streamingPlugin.destroy(mountpointId);
       })
       .then(function(response) {
-        assert.equal(response.getData()['destroyed'], mountpointId);
+        assert.equal(response.getData('destroyed'), mountpointId);
         done();
       });
   });

--- a/test/integration/streaming.js
+++ b/test/integration/streaming.js
@@ -57,10 +57,11 @@ describe('Steraming tests', function() {
     var mountpointId = randomMountpointId();
     streamingPlugin.create(mountpointId, mountpointOptions)
       .then(function(response) {
-        assert.equal(response['stream']['id'], mountpointId);
+        assert.equal(response.getData()['stream']['id'], mountpointId);
         return streamingPlugin.list();
       })
-      .then(function(list) {
+      .then(function(response) {
+        var list = response.getData()['list'];
         var createdMountpoint = jQuery.grep(list, function(mountpoint) {
           return mountpoint.id == mountpointId;
         });
@@ -68,7 +69,7 @@ describe('Steraming tests', function() {
         return streamingPlugin.destroy(mountpointId);
       })
       .then(function(response) {
-        assert.equal(response['plugindata']['data']['destroyed'], mountpointId);
+        assert.equal(response.getData()['destroyed'], mountpointId);
         done();
       });
   });


### PR DESCRIPTION
I have an inconsistency now, unfortunately. Here it is:
 - `list` actions always return `response['plugindata']['data']['list']`
 - `create` actions return `response['plugindata']['data']`
 - all other plugin actions return `response`

The complete janus response messages is meant by `response` above. My question is should we keep it as it is now or shall we unify all methods to return `response`? We can't always return `response['plugindata']['data']` cause we need to access once `response['jsep']` in `configure` action of Audioroom/Audiobridge plugins.

@zazabe @tomaszdurka your thoughts?