### PR TITLE
WebsocketConnection events are not propagated properly to Connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "janus-gateway-js",
   "description": "Core concepts for Janus javascript client",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "src/index.js",

--- a/src/connection.js
+++ b/src/connection.js
@@ -55,9 +55,9 @@ Connection.create = function(id, address, options) {
  * @protected
  */
 Connection.prototype._installWebsocketListeners = function() {
-  this._websocketConnection.on('open', this.emit.bind(this));
-  this._websocketConnection.on('error', this.emit.bind(this));
-  this._websocketConnection.on('close', this.emit.bind(this));
+  this._websocketConnection.on('open', this.emit.bind(this, 'open'));
+  this._websocketConnection.on('error', this.emit.bind(this, 'error'));
+  this._websocketConnection.on('close', this.emit.bind(this, 'close'));
   this._websocketConnection.on('message', this.processIncomeMessage.bind(this));
 };
 


### PR DESCRIPTION
All the calls in https://github.com/cargomedia/janus-gateway-js/blob/master/src/connection.js#L57 misses argument about the event.

```js
this._websocketConnection.on('open', this.emit.bind(this));
this._websocketConnection.emit('open', 'data');
```
Above code will emit `data` event instead of `open` event with `data`. We need to pass event name.

```js
this._websocketConnection.on('open', this.emit.bind(this, 'open'));
```

@vogdb wdyt?