### PR TITLE
Customized build

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,18 @@ janus.createConnection('id').then(function(connection) {
 ```
 
 ## Build
-To build the project use `npm run-script build`.
+Project has a customized build. By default `npm run-script build` it builds the single file `janus.js` that contains Janus library and all its dependencies. In order to make the result less in size you have two command line arguments: `--global` and `--external`. The first is to map dependencies to global variables. Usually you want to do this when there is no loader mechanism. The latter is to externalize dependencies to a separate file `vendor.js`. In that case `janus.js` expects to have its dependencies as modules and relies on `require` mechanism.
+Here is the couple of examples.
+ - `bluebird` and `webrtc-adapter` are externalized to `vendor.js`
+
+   ```
+   $(npm bin)/gulp --external=bluebird --external=webrtc-adapter
+   ```
+ - `bluebird` and `webrtc-adapter` are expected to be in global namespace under names `Promise` and `adapter` correspondingly.
+
+   ```
+   $(npm bin)/gulp --global.bluebird=Promise --global.webrtc-adapter=adapter
+   ```
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ janus.createConnection('id').then(function(connection) {
 ## Build
 Project has a customized build. By default `npm run-script build` it builds the single file `janus.js` that contains Janus library and all its dependencies. In order to make the result less in size you have two command line arguments: `--global` and `--external`. The first is to map dependencies to global variables. Usually you want to do this when there is no loader mechanism. The latter is to externalize dependencies to a separate file `vendor.js`. In that case `janus.js` expects to have its dependencies as modules and relies on `require` mechanism.
 Here is the couple of examples.
+ - Default build. It is used in integration tests.
+
+   ```
+   $(npm bin)/gulp
+   ```
+
  - `bluebird` and `webrtc-adapter` are externalized to `vendor.js`
 
    ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,12 +81,6 @@ var buildTask = function(global, external) {
   browserifyTask(global, external);
 };
 
-var watchTask = function() {
-  gulp.watch("./src/*.js", ['browserify']);
-};
-
-gulp.task('watch', watchTask);
-
 gulp.task('default', function(global, external) {
   buildTask(global, external);
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
-var gulp = require('gulp');
+var _ = require('underscore');
+var gulp = require('gulp-param')(require('gulp'), process.argv);
 var rename = require("gulp-rename");
 var browserify = require('browserify');
 
@@ -10,16 +11,24 @@ var gutil = require('gulp-util');
 var exorcist = require('exorcist');
 var nodeResolve = require('resolve');
 
-var browserifyTask = function() {
+var browserifyTask = function(global, external) {
   var b = browserify({
     entries: './src/index.js',
     standalone: 'Janus',
     debug: true
   });
 
-  vendor.forEach(function(lib) {
-    b.external(lib);
-  });
+  if (external) {
+    if (!_.isArray(external)) {
+      external = [external];
+    }
+    external.forEach(function(lib) {
+      b.external(lib);
+    });
+  }
+  if (_.isObject(global)) {
+    b.transform('exposify', {expose: global});
+  }
 
   return b.bundle()
     .pipe(exorcist('./dist/janus.js.map'))
@@ -36,41 +45,40 @@ var browserifyTask = function() {
 
 gulp.task('browserify', browserifyTask);
 
-var vendor = [
-  'bluebird',
-  'webrtc-adapter'
-];
-
-var vendorTask = function() {
+var vendorTask = function(external) {
   var b = browserify();
+  if (external) {
+    if (!_.isArray(external)) {
+      external = [external];
+    }
+    external.forEach(function(id) {
+      b.require(nodeResolve.sync(id), {expose: id});
+    });
 
-  vendor.forEach(function(id) {
-    b.require(nodeResolve.sync(id), {expose: id});
-  });
+    var stream = b
+      .bundle()
+      .on('error', function(err) {
+        console.log(err.message);
+        this.emit('end');
+      })
+      .pipe(source('vendor.js'));
 
-  var stream = b
-    .bundle()
-    .on('error', function(err) {
-      console.log(err.message);
-      this.emit('end');
-    })
-    .pipe(source('vendor.js'));
+    stream
+      .pipe(gulp.dest('./dist'))
+      .pipe(rename('vendor.min.js'))
+      .pipe(buffer())
+      .pipe(uglify())
+      .pipe(gulp.dest('./dist'));
 
-  stream
-    .pipe(gulp.dest('./dist'))
-    .pipe(rename('vendor.min.js'))
-    .pipe(buffer())
-    .pipe(uglify())
-    .pipe(gulp.dest('./dist'));
-
-  return stream;
+    return stream;
+  }
 };
 
 gulp.task('vendor', vendorTask);
 
-var buildTask = function() {
-  vendorTask();
-  browserifyTask();
+var buildTask = function(global, external) {
+  vendorTask(external);
+  browserifyTask(global, external);
 };
 
 var watchTask = function() {
@@ -79,6 +87,6 @@ var watchTask = function() {
 
 gulp.task('watch', watchTask);
 
-gulp.task('default', function() {
-  buildTask();
+gulp.task('default', function(global, external) {
+  buildTask(global, external);
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "url": "git@github.com:cargomedia/janus-gateway-js.git"
   },
   "scripts": {
-    "browser": "browserify ./src/index.js -o ./dist/janus.js",
     "build": "npm install && $(npm bin)/gulp",
     "test": "$(npm bin)/mocha && $(npm bin)/karma start test/karma.conf.js",
     "test-codecov": "$(npm bin)/istanbul cover $(npm bin)/_mocha -- -R spec && cat ./coverage/coverage.json | $(npm bin)/codecov"
@@ -26,8 +25,10 @@
     "chai": "^2.1.2",
     "codecov.io": "^0.1.6",
     "exorcist": "^0.4.0",
+    "exposify": "^0.5.0",
     "gulp": "^3.9.1",
     "gulp-browserify": "^0.5.1",
+    "gulp-param": "^1.0.3",
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "janus-gateway-js",
   "description": "Core concepts for Janus javascript client",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "src/index.js",

--- a/test/integration/audiobridge.js
+++ b/test/integration/audiobridge.js
@@ -7,11 +7,11 @@ describe('Audiobridge tests', function() {
     return Math.floor(Math.random() * 1000 + 1);
   }
 
-  before(function(done) {
+  before(function() {
     this.timeout(4000);
     $('body').append('<audio id="audio" autoplay></audio>');
 
-    jQuery.getJSON('./config.json')
+    return jQuery.getJSON('./config.json')
       .then(function(config) {
         var janus = new Janus.Client(config.url, config);
         return janus.createConnection('client');
@@ -22,36 +22,32 @@ describe('Audiobridge tests', function() {
       })
       .then(function(session) {
         janusSession = session;
-        done();
-      })
-      .catch(done);
-  });
-
-  after(function(done) {
-    $('#audio').remove();
-
-    janusSession.destroy()
-      .then(function() {
-        return janusConnection.close();
-      })
-      .then(done);
-  });
-
-  beforeEach(function(done) {
-    janusSession.attachPlugin(Janus.AudiobridgePlugin.NAME)
-      .then(function(plugin) {
-        audiobridgePlugin = plugin;
-        done();
       });
   });
 
-  afterEach(function(done) {
-    audiobridgePlugin.detach().then(done);
+  after(function() {
+    $('#audio').remove();
+
+    return janusSession.destroy()
+      .then(function() {
+        return janusConnection.close();
+      });
   });
 
-  it('creates, connects, lists', function(done) {
+  beforeEach(function() {
+    return janusSession.attachPlugin(Janus.AudiobridgePlugin.NAME)
+      .then(function(plugin) {
+        audiobridgePlugin = plugin;
+      });
+  });
+
+  afterEach(function() {
+    return audiobridgePlugin.detach();
+  });
+
+  it('creates, connects, lists', function() {
     var roomId = randomRoomId();
-    audiobridgePlugin.create(roomId)
+    return audiobridgePlugin.create(roomId)
       .then(function(response) {
         assert.equal(response.getData('audiobridge'), 'created');
         return audiobridgePlugin.join(roomId);
@@ -66,13 +62,12 @@ describe('Audiobridge tests', function() {
           return room.room == roomId;
         });
         assert.equal(createdRoom.length, 1);
-        done();
       });
   });
 
-  it('lists participants', function(done) {
+  it('lists participants', function() {
     var roomId = randomRoomId();
-    audiobridgePlugin.create(roomId)
+    return audiobridgePlugin.create(roomId)
       .then(function() {
         return audiobridgePlugin.connect(roomId);
       })
@@ -82,14 +77,13 @@ describe('Audiobridge tests', function() {
       .then(function(response) {
         var participants = response.getData('participants');
         assert.equal(participants.length, 1);
-        done();
       });
   });
 
-  it('changes room when connect', function(done) {
+  it('changes room when connect', function() {
     var roomId1 = randomRoomId();
     var roomId2 = randomRoomId();
-    audiobridgePlugin.create(roomId1)
+    return audiobridgePlugin.create(roomId1)
       .then(function() {
         return audiobridgePlugin.create(roomId2);
       })
@@ -101,7 +95,6 @@ describe('Audiobridge tests', function() {
       })
       .then(function(response) {
         assert.equal(response.getData('audiobridge'), 'roomchanged');
-        done();
       });
   });
 
@@ -127,11 +120,11 @@ describe('Audiobridge tests', function() {
       });
   });
 
-  it('stops media on detach', function(done) {
+  it('stops media on detach', function() {
     var roomId = randomRoomId();
     var pc;
 
-    audiobridgePlugin.create(roomId)
+    return audiobridgePlugin.create(roomId)
       .then(function() {
         return audiobridgePlugin.connect(roomId);
       })
@@ -149,7 +142,6 @@ describe('Audiobridge tests', function() {
       })
       .then(function() {
         assert.strictEqual(pc.getLocalStreams()[0].active, false);
-        done();
       });
   });
 

--- a/test/integration/audiobridge.js
+++ b/test/integration/audiobridge.js
@@ -8,6 +8,7 @@ describe('Audiobridge tests', function() {
   }
 
   before(function(done) {
+    this.timeout(4000);
     $('body').append('<audio id="audio" autoplay></audio>');
 
     jQuery.getJSON('./config.json')
@@ -22,7 +23,8 @@ describe('Audiobridge tests', function() {
       .then(function(session) {
         janusSession = session;
         done();
-      });
+      })
+      .catch(done);
   });
 
   after(function(done) {

--- a/test/integration/audiobridge.js
+++ b/test/integration/audiobridge.js
@@ -113,7 +113,7 @@ describe('Audiobridge tests', function() {
 
     audiobridgePlugin.on('pc:addstream', function(event) {
       assert(event.stream);
-      require('webrtc-adapter').browserShim.attachMediaStream(audio, event.stream);
+      adapter.browserShim.attachMediaStream(audio, event.stream);
     });
 
     audiobridgePlugin.create(roomId)

--- a/test/integration/audioroom.js
+++ b/test/integration/audioroom.js
@@ -7,11 +7,11 @@ describe('Audioroom tests', function() {
     return Math.random().toString().substring(2, 12);
   }
 
-  before(function(done) {
+  before(function() {
     this.timeout(4000);
     $('body').append('<audio id="audio" autoplay></audio>');
 
-    jQuery.getJSON('./config.json')
+    return jQuery.getJSON('./config.json')
       .then(function(config) {
         var janus = new Janus.Client(config.url, config);
         return janus.createConnection('client');
@@ -22,36 +22,32 @@ describe('Audioroom tests', function() {
       })
       .then(function(session) {
         janusSession = session;
-        done();
-      })
-      .catch(done);
-  });
-
-  after(function(done) {
-    $('#audio').remove();
-
-    janusSession.destroy()
-      .then(function() {
-        return janusConnection.close();
-      })
-      .then(done);
-  });
-
-  beforeEach(function(done) {
-    janusSession.attachPlugin(Janus.AudioroomPlugin.NAME)
-      .then(function(plugin) {
-        audioroomPlugin = plugin;
-        done();
       });
   });
 
-  afterEach(function(done) {
-    audioroomPlugin.detach().then(done);
+  after(function() {
+    $('#audio').remove();
+
+    return janusSession.destroy()
+      .then(function() {
+        return janusConnection.close();
+      });
   });
 
-  it('connects, lists', function(done) {
+  beforeEach(function() {
+    return janusSession.attachPlugin(Janus.AudioroomPlugin.NAME)
+      .then(function(plugin) {
+        audioroomPlugin = plugin;
+      });
+  });
+
+  afterEach(function() {
+    return audioroomPlugin.detach();
+  });
+
+  it('connects, lists', function() {
     var roomId = randomRoomId();
-    audioroomPlugin.connect(roomId)
+    return audioroomPlugin.connect(roomId)
       .then(function(response) {
         assert.equal(response.getData('audioroom'), 'joined');
         return audioroomPlugin.list();
@@ -62,33 +58,30 @@ describe('Audioroom tests', function() {
           return room.id == roomId;
         });
         assert.equal(createdRoom.length, 1);
-        done();
       });
   });
 
-  it('lists participants', function(done) {
+  it('lists participants', function() {
     var roomId = randomRoomId();
-    audioroomPlugin.connect(roomId)
+    return audioroomPlugin.connect(roomId)
       .then(function() {
         return audioroomPlugin.listParticipants(roomId);
       })
       .then(function(response) {
         var participants = response.getData('participants');
         assert.equal(participants.length, 1);
-        done();
       });
   });
 
-  it('changes room on the fly when connect', function(done) {
+  it('changes room on the fly when connect', function() {
     var roomId1 = randomRoomId();
     var roomId2 = randomRoomId();
-    audioroomPlugin.connect(roomId1)
+    return audioroomPlugin.connect(roomId1)
       .then(function() {
         return audioroomPlugin.connect(roomId2);
       })
       .then(function(response) {
         assert.equal(response.getData('audioroom'), 'roomchanged');
-        done();
       });
   });
 
@@ -111,11 +104,11 @@ describe('Audioroom tests', function() {
       });
   });
 
-  it('stops media on detach', function(done) {
+  it('stops media on detach', function() {
     var roomId = randomRoomId();
     var pc;
 
-    audioroomPlugin.connect(roomId)
+    return audioroomPlugin.connect(roomId)
       .then(function() {
         return audioroomPlugin.startMediaStreaming({muted: false});
       })
@@ -130,7 +123,6 @@ describe('Audioroom tests', function() {
       })
       .then(function() {
         assert.strictEqual(pc.getLocalStreams()[0].active, false);
-        done();
       });
   });
 

--- a/test/integration/audioroom.js
+++ b/test/integration/audioroom.js
@@ -8,6 +8,7 @@ describe('Audioroom tests', function() {
   }
 
   before(function(done) {
+    this.timeout(4000);
     $('body').append('<audio id="audio" autoplay></audio>');
 
     jQuery.getJSON('./config.json')
@@ -22,7 +23,8 @@ describe('Audioroom tests', function() {
       .then(function(session) {
         janusSession = session;
         done();
-      });
+      })
+      .catch(done);
   });
 
   after(function(done) {

--- a/test/integration/audioroom.js
+++ b/test/integration/audioroom.js
@@ -100,7 +100,7 @@ describe('Audioroom tests', function() {
 
     audioroomPlugin.on('pc:addstream', function(event) {
       assert(event.stream);
-      require('webrtc-adapter').browserShim.attachMediaStream(audio, event.stream);
+      adapter.browserShim.attachMediaStream(audio, event.stream);
     });
 
     audioroomPlugin.connect(roomId)

--- a/test/integration/index.html
+++ b/test/integration/index.html
@@ -11,6 +11,7 @@
       assert = chai.assert;
     </script>
     <script src="../../node_modules/jquery/dist/jquery.min.js"></script>
+    <script src="../../node_modules/webrtc-adapter/out/adapter.js"></script>
     <script src="../../dist/vendor.js"></script>
     <script src="../../dist/janus.js"></script>
   </head>
@@ -24,7 +25,7 @@
 
     <script>
       mocha.checkLeaks();
-      mocha.globals(['jQuery', 'Janus']);
+      mocha.globals(['jQuery', 'Janus', 'adapter']);
       mocha.run();
     </script>
   </body>

--- a/test/integration/index.html
+++ b/test/integration/index.html
@@ -12,7 +12,6 @@
     </script>
     <script src="../../node_modules/jquery/dist/jquery.min.js"></script>
     <script src="../../node_modules/webrtc-adapter/out/adapter.js"></script>
-    <script src="../../dist/vendor.js"></script>
     <script src="../../dist/janus.js"></script>
   </head>
   <body>

--- a/test/integration/janus.js
+++ b/test/integration/janus.js
@@ -2,11 +2,13 @@ describe('Janus basic tests', function() {
   var janusConfig;
 
   before(function(done) {
+    this.timeout(4000);
     jQuery.getJSON('./config.json')
       .then(function(config) {
         janusConfig = config;
         done();
-      });
+      })
+      .catch(done);
   });
 
   it('creates connection', function(done) {

--- a/test/integration/janus.js
+++ b/test/integration/janus.js
@@ -1,30 +1,27 @@
 describe('Janus basic tests', function() {
   var janusConfig;
 
-  before(function(done) {
+  before(function() {
     this.timeout(4000);
-    jQuery.getJSON('./config.json')
+    return jQuery.getJSON('./config.json')
       .then(function(config) {
         janusConfig = config;
-        done();
-      })
-      .catch(done);
+      });
   });
 
-  it('creates connection', function(done) {
+  it('creates connection', function() {
     var janus = new Janus.Client(janusConfig.url, janusConfig);
-    janus.createConnection('client')
+    return janus.createConnection('client')
       .then(function(connection) {
         assert(connection);
         return connection.close();
-      })
-      .then(done);
+      });
   });
 
-  it('creates session', function(done) {
+  it('creates session', function() {
     var janus = new Janus.Client(janusConfig.url, janusConfig);
     var janusConnection;
-    janus.createConnection('client')
+    return janus.createConnection('client')
       .then(function(connection) {
         janusConnection = connection;
         return connection.createSession();
@@ -35,8 +32,7 @@ describe('Janus basic tests', function() {
       })
       .then(function() {
         return janusConnection.close();
-      })
-      .then(done);
+      });
   });
 
 });

--- a/test/integration/rtpbroadcast.js
+++ b/test/integration/rtpbroadcast.js
@@ -19,11 +19,11 @@ describe('Rtpbroadcast tests', function() {
     return Math.random().toString(36).substring(2, 12);
   }
 
-  before(function(done) {
+  before(function() {
     this.timeout(4000);
     $('body').append('<video id="video" autoplay></video>');
 
-    jQuery.getJSON('./config.json')
+    return jQuery.getJSON('./config.json')
       .then(function(config) {
         var janus = new Janus.Client(config.url, config);
         return janus.createConnection('client');
@@ -34,36 +34,32 @@ describe('Rtpbroadcast tests', function() {
       })
       .then(function(session) {
         janusSession = session;
-        done();
-      })
-      .catch(done);
-  });
-
-  after(function(done) {
-    $('#video').remove();
-
-    janusSession.destroy()
-      .then(function() {
-        return janusConnection.close();
-      })
-      .then(done);
-  });
-
-  beforeEach(function(done) {
-    janusSession.attachPlugin(Janus.RtpbroadcastPlugin.NAME)
-      .then(function(plugin) {
-        rtpbroadcastPlugin = plugin;
-        done();
       });
   });
 
-  afterEach(function(done) {
-    rtpbroadcastPlugin.detach().then(done);
+  after(function() {
+    $('#video').remove();
+
+    return janusSession.destroy()
+      .then(function() {
+        return janusConnection.close();
+      });
   });
 
-  it('creates, lists and destroys', function(done) {
+  beforeEach(function() {
+    return janusSession.attachPlugin(Janus.RtpbroadcastPlugin.NAME)
+      .then(function(plugin) {
+        rtpbroadcastPlugin = plugin;
+      });
+  });
+
+  afterEach(function() {
+    return rtpbroadcastPlugin.detach();
+  });
+
+  it('creates, lists and destroys', function() {
     var mountpointId = randomMountpointId();
-    rtpbroadcastPlugin.create(mountpointId, mountpointOptions)
+    return rtpbroadcastPlugin.create(mountpointId, mountpointOptions)
       .then(function(response) {
         assert.equal(response.getData('created'), mountpointOptions['name']);
         return rtpbroadcastPlugin.list(mountpointId);
@@ -78,7 +74,6 @@ describe('Rtpbroadcast tests', function() {
       })
       .then(function(response) {
         assert.equal(response.getData('destroyed'), mountpointId);
-        done();
       });
   });
 
@@ -107,10 +102,10 @@ describe('Rtpbroadcast tests', function() {
       });
   });
 
-  it('pauses, starts, stops and destroys', function(done) {
+  it('pauses, starts, stops and destroys', function() {
     this.timeout(5000);
     var mountpointId = randomMountpointId();
-    rtpbroadcastPlugin.create(mountpointId, mountpointOptions)
+    return rtpbroadcastPlugin.create(mountpointId, mountpointOptions)
       .then(function() {
         return rtpbroadcastPlugin.watch(mountpointId);
       })
@@ -125,9 +120,6 @@ describe('Rtpbroadcast tests', function() {
       .delay(300)
       .then(function() {
         return rtpbroadcastPlugin.stop();
-      })
-      .then(function() {
-        done();
       });
   });
 

--- a/test/integration/rtpbroadcast.js
+++ b/test/integration/rtpbroadcast.js
@@ -20,6 +20,7 @@ describe('Rtpbroadcast tests', function() {
   }
 
   before(function(done) {
+    this.timeout(4000);
     $('body').append('<video id="video" autoplay></video>');
 
     jQuery.getJSON('./config.json')
@@ -34,7 +35,8 @@ describe('Rtpbroadcast tests', function() {
       .then(function(session) {
         janusSession = session;
         done();
-      });
+      })
+      .catch(done);
   });
 
   after(function(done) {

--- a/test/integration/rtpbroadcast.js
+++ b/test/integration/rtpbroadcast.js
@@ -88,7 +88,7 @@ describe('Rtpbroadcast tests', function() {
     });
     rtpbroadcastPlugin.on('pc:addstream', function(event) {
       assert(event.stream);
-      require('webrtc-adapter').browserShim.attachMediaStream(video, event.stream);
+      adapter.browserShim.attachMediaStream(video, event.stream);
     });
 
     var mountpointId = randomMountpointId();

--- a/test/integration/streaming.js
+++ b/test/integration/streaming.js
@@ -15,11 +15,11 @@ describe('Steraming tests', function() {
     return Math.floor(Math.random() * 1000 + 1);
   }
 
-  before(function(done) {
+  before(function() {
     this.timeout(4000);
     $('body').append('<video id="video" autoplay></video>');
 
-    jQuery.getJSON('./config.json')
+    return jQuery.getJSON('./config.json')
       .then(function(config) {
         var janus = new Janus.Client(config.url, config);
         return janus.createConnection('client');
@@ -30,36 +30,32 @@ describe('Steraming tests', function() {
       })
       .then(function(session) {
         janusSession = session;
-        done();
-      })
-      .catch(done);
-  });
-
-  after(function(done) {
-    $('#video').remove();
-
-    janusSession.destroy()
-      .then(function() {
-        return janusConnection.close();
-      })
-      .then(done);
-  });
-
-  beforeEach(function(done) {
-    janusSession.attachPlugin(Janus.StreamingPlugin.NAME)
-      .then(function(plugin) {
-        streamingPlugin = plugin;
-        done();
       });
   });
 
-  afterEach(function(done) {
-    streamingPlugin.detach().then(done);
+  after(function() {
+    $('#video').remove();
+
+    return janusSession.destroy()
+      .then(function() {
+        return janusConnection.close();
+      });
   });
 
-  it('creates, lists and destroys', function(done) {
+  beforeEach(function() {
+    return janusSession.attachPlugin(Janus.StreamingPlugin.NAME)
+      .then(function(plugin) {
+        streamingPlugin = plugin;
+      });
+  });
+
+  afterEach(function() {
+    return streamingPlugin.detach();
+  });
+
+  it('creates, lists and destroys', function() {
     var mountpointId = randomMountpointId();
-    streamingPlugin.create(mountpointId, mountpointOptions)
+    return streamingPlugin.create(mountpointId, mountpointOptions)
       .then(function(response) {
         assert.equal(response.getData('stream', 'id'), mountpointId);
         return streamingPlugin.list();
@@ -74,7 +70,6 @@ describe('Steraming tests', function() {
       })
       .then(function(response) {
         assert.equal(response.getData('destroyed'), mountpointId);
-        done();
       });
   });
 
@@ -99,10 +94,10 @@ describe('Steraming tests', function() {
       });
   });
 
-  it('pauses, starts, stops and destroys', function(done) {
+  it('pauses, starts, stops and destroys', function() {
     this.timeout(5000);
     var mountpointId = randomMountpointId();
-    streamingPlugin.create(mountpointId, mountpointOptions)
+    return streamingPlugin.create(mountpointId, mountpointOptions)
       .then(function() {
         return streamingPlugin.connect(mountpointId);
       })
@@ -117,9 +112,6 @@ describe('Steraming tests', function() {
       .delay(300)
       .then(function() {
         return streamingPlugin.stop();
-      })
-      .then(function() {
-        done();
       });
   });
 

--- a/test/integration/streaming.js
+++ b/test/integration/streaming.js
@@ -84,7 +84,7 @@ describe('Steraming tests', function() {
     });
     streamingPlugin.on('pc:addstream', function(event) {
       assert(event.stream);
-      require('webrtc-adapter').browserShim.attachMediaStream(video, event.stream);
+      adapter.browserShim.attachMediaStream(video, event.stream);
     });
 
     var mountpointId = randomMountpointId();

--- a/test/integration/streaming.js
+++ b/test/integration/streaming.js
@@ -16,6 +16,7 @@ describe('Steraming tests', function() {
   }
 
   before(function(done) {
+    this.timeout(4000);
     $('body').append('<video id="video" autoplay></video>');
 
     jQuery.getJSON('./config.json')
@@ -30,7 +31,8 @@ describe('Steraming tests', function() {
       .then(function(session) {
         janusSession = session;
         done();
-      });
+      })
+      .catch(done);
   });
 
   after(function(done) {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
     files: [
       {pattern: 'test/integration/*.json', watched: true, served: true, included: false},
       'node_modules/jquery/dist/jquery.min.js',
-      'dist/vendor.js',
+      'node_modules/webrtc-adapter/out/adapter.js',
       'dist/janus.js',
       'test/integration/*.js'
     ],


### PR DESCRIPTION
Currently we force only one build possible when `bluebird` and `webrtc-adapter` go in `vendor.js` and `janus.js` expects those dependencies through `require.js` mechanism. I think that we need to give an ability to customize the build. Some people would like to have only `webrtc-adapter` in vendor, some expect `bluebird` to be available in global and etc.