### PR TITLE
MediaAudioPlugin API refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ The library is available for Node and Browser environment. In Browser it is decl
     * `track` MediaStreamTrack
     * `stream` MediaStream. Stream that contains tracks. Repeatable parameter.
 
- * `plugin.getLocalMedia(constraints)`
+ * `plugin.getUserMedia(constraints)`
 
     Wraps MediaDevices.getUserMedia with additional constraint for screen-capturing. Returns promise.
     * `constraints` MediaStreamConstraints
@@ -592,7 +592,7 @@ For simplicity lets write an [EchoTest plugin](https://janus.conf.meetecho.com/d
     var self = this;
     return Promise
       .try(function() {
-        return self.getLocalMedia({audio: true, video: false});
+        return self.getUserMedia({audio: true, video: false});
       })
       .then(function(stream) {
         self.createPeerConnection();

--- a/README.md
+++ b/README.md
@@ -358,11 +358,12 @@ The library is available for Node and Browser environment. In Browser it is decl
     * `options` Object. see JSDocu.
     * `jsep` RTCSessionDescription
 
- * `plugin.startMediaStreaming([offerOptions], [configureOptions])`
+ * `plugin.offerStream(stream, [offerOptions], [configureOptions])`
 
-    Takes user's audio input, creates a peer connection with it and sends an offer. Returns a promise that is resolved with `sendSDP` promise.
+    Creates a peer connection with the stream and sends an offer. Returns a promise that is resolved with `sendSDP` promise.
+    * `stream` MediaStream.
     * `offerOptions` Object. Options for the offer.
-    * `configureOptions` Object. Options to configure room after the offer send.
+    * `configureOptions` Object. Options to configure room after the offer is sent.
 
  * `plugin.sendSDP(jsep, [configureOptions])`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "janus-gateway-js",
   "description": "Core concepts for Janus javascript client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "src/index.js",

--- a/src/webrtc/media-audio-plugin.js
+++ b/src/webrtc/media-audio-plugin.js
@@ -114,6 +114,7 @@ MediaAudioPlugin.prototype.configure = function(options, jsep) {
 };
 
 /**
+ * @param {MediaStream} stream
  * @param {RTCOfferOptions} [offerOptions]
  * @param {Object} [configureOptions]
  * @param {boolean} [configureOptions.muted]
@@ -121,15 +122,12 @@ MediaAudioPlugin.prototype.configure = function(options, jsep) {
  * @returns {Promise}
  * @fulfilled {@link sendSDP}
  */
-MediaAudioPlugin.prototype.startMediaStreaming = function(offerOptions, configureOptions) {
+MediaAudioPlugin.prototype.offerStream = function(stream, offerOptions, configureOptions) {
   var self = this;
   return Promise
     .try(function() {
-      return self.getLocalMedia({audio: true, video: false});
-    })
-    .then(function(stream) {
       self.createPeerConnection();
-      stream.getTracks().forEach(function(track) {
+      stream.getAudioTracks().forEach(function(track) {
         self.addTrack(track, stream);
       });
     })

--- a/src/webrtc/media-plugin.js
+++ b/src/webrtc/media-plugin.js
@@ -85,7 +85,7 @@ MediaPlugin.prototype.addTrack = function(track, stream) {
  * @returns {Promise}
  * @fulfilled {MediaStream} stream
  */
-MediaPlugin.prototype.getLocalMedia = function(constraints) {
+MediaPlugin.prototype.getUserMedia = function(constraints) {
   this.emit('consent-dialog:start');
   var self = this;
   var promise = MediaDevicesShim.getUserMedia(constraints);

--- a/test/integration/audiobridge.js
+++ b/test/integration/audiobridge.js
@@ -116,7 +116,7 @@ describe('Audiobridge tests', function() {
         return audiobridgePlugin.connect(roomId);
       })
       .then(function() {
-        return audiobridgePlugin.getLocalMedia({audio: true, video: false});
+        return audiobridgePlugin.getUserMedia({audio: true, video: false});
       })
       .then(function(stream) {
         return audiobridgePlugin.offerStream(stream, null, {muted: false});
@@ -132,7 +132,7 @@ describe('Audiobridge tests', function() {
         return audiobridgePlugin.connect(roomId);
       })
       .then(function() {
-        return audiobridgePlugin.getLocalMedia({audio: true, video: false});
+        return audiobridgePlugin.getUserMedia({audio: true, video: false});
       })
       .then(function(stream) {
         return audiobridgePlugin.offerStream(stream, null, {muted: false});

--- a/test/integration/audiobridge.js
+++ b/test/integration/audiobridge.js
@@ -116,7 +116,10 @@ describe('Audiobridge tests', function() {
         return audiobridgePlugin.connect(roomId);
       })
       .then(function() {
-        return audiobridgePlugin.startMediaStreaming({muted: false});
+        return audiobridgePlugin.getLocalMedia({audio: true, video: false});
+      })
+      .then(function(stream) {
+        return audiobridgePlugin.offerStream(stream, null, {muted: false});
       });
   });
 
@@ -129,7 +132,10 @@ describe('Audiobridge tests', function() {
         return audiobridgePlugin.connect(roomId);
       })
       .then(function() {
-        return audiobridgePlugin.startMediaStreaming({muted: false});
+        return audiobridgePlugin.getLocalMedia({audio: true, video: false});
+      })
+      .then(function(stream) {
+        return audiobridgePlugin.offerStream(stream, null, {muted: false});
       })
       .delay(1000)
       .then(function() {

--- a/test/integration/audioroom.js
+++ b/test/integration/audioroom.js
@@ -100,7 +100,10 @@ describe('Audioroom tests', function() {
 
     audioroomPlugin.connect(roomId)
       .then(function() {
-        return audioroomPlugin.startMediaStreaming({muted: false});
+        return audioroomPlugin.getLocalMedia({audio: true, video: false});
+      })
+      .then(function(stream) {
+        return audioroomPlugin.offerStream(stream, null, {muted: false});
       });
   });
 
@@ -110,7 +113,10 @@ describe('Audioroom tests', function() {
 
     return audioroomPlugin.connect(roomId)
       .then(function() {
-        return audioroomPlugin.startMediaStreaming({muted: false});
+        return audioroomPlugin.getLocalMedia({audio: true, video: false});
+      })
+      .then(function(stream) {
+        return audioroomPlugin.offerStream(stream, null, {muted: false});
       })
       .delay(1000)
       .then(function() {

--- a/test/integration/audioroom.js
+++ b/test/integration/audioroom.js
@@ -100,7 +100,7 @@ describe('Audioroom tests', function() {
 
     audioroomPlugin.connect(roomId)
       .then(function() {
-        return audioroomPlugin.getLocalMedia({audio: true, video: false});
+        return audioroomPlugin.getUserMedia({audio: true, video: false});
       })
       .then(function(stream) {
         return audioroomPlugin.offerStream(stream, null, {muted: false});
@@ -113,7 +113,7 @@ describe('Audioroom tests', function() {
 
     return audioroomPlugin.connect(roomId)
       .then(function() {
-        return audioroomPlugin.getLocalMedia({audio: true, video: false});
+        return audioroomPlugin.getUserMedia({audio: true, video: false});
       })
       .then(function(stream) {
         return audioroomPlugin.offerStream(stream, null, {muted: false});


### PR DESCRIPTION
We force user of method only to one type of audio input === user microphone. That is wrong. User should be able to pass any stream he wants. May be he wants a recorded audio?