### PR TITLE
emitting of janus errors and messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,20 +553,20 @@ The library is available for Node and Browser environment. In Browser it is decl
 
 
 ### Error
- Custom Janus errors. All Janus entities use them for controlled errors.
+ Custom Janus errors. Used for controlled errors that happen on janus messages.
 #### JanusError
- * `new JanusError(reason, code, janusMessage)`
+ * `new JanusError(janusMessage)`
 
     Creates a new instance of JanusError.
-    * `reason` {string} text of error.
-    * `code` {number} code of error.
-    * `janusMessage` {Object} message that caused the error.
+    * `janusMessage` {JanusMessage} message that caused the error.
 
-#### ConnectionError
- * `new ConnectionError(janusMessage)`
+ * `error.code`
 
-    Creates a new instance of ConnectionError. Extends JanusError.
-    * `janusMessage` {Object} message that caused the error.
+    Janus error code
+
+ * `error.janusMessage`
+
+    Janus message of error
 
 ## Tests
 Tests are located under `test/` directory. To run them use `npm test`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "janus-gateway-js",
   "description": "Core concepts for Janus javascript client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": "Cargomedia",
   "license": "MIT",
   "main": "src/index.js",

--- a/src/connection.js
+++ b/src/connection.js
@@ -249,7 +249,7 @@ Connection.prototype._onCreate = function(outcomeMessage) {
       this.addSession(Session.create(this, sessionId));
       return this.getSession(sessionId);
     } else {
-      throw new JanusError.ConnectionError(incomeMessage);
+      throw new JanusError(incomeMessage);
     }
   }.bind(this)));
   return Promise.resolve(outcomeMessage);

--- a/src/error.js
+++ b/src/error.js
@@ -1,37 +1,18 @@
 var Helpers = require('./helpers');
 
 /**
- * @param {string} reason
- * @param {number} code
- * @param {JanusMessage} [janusMessage]
+ * @param {JanusMessage} janusMessage
  * @constructor
  */
-function JanusError(reason, code, janusMessage) {
+function JanusError(janusMessage) {
   Error.captureStackTrace(this, this.constructor);
   this.name = this.constructor.name;
-  this.message = reason;
-  this.code = code;
-  this.janusMessage = janusMessage
+  this.janusMessage = janusMessage;
+  var janusError = janusMessage.getError();
+  this.message = janusError['reason'];
+  this.code = janusError['code'];
 }
 
 Helpers.inherits(JanusError, Error);
 
-/**
- * @param {JanusMessage} janusMessage
- * @constructor
- * @extends JanusError
- */
-function ConnectionError(janusMessage) {
-  var code = 500;
-  var reason = 'Unknown error';
-  var error = janusMessage.getError();
-  if (error) {
-    reason = error['reason'];
-    code = error['code'];
-  }
-  ConnectionError.super_.call(this, reason, code, janusMessage);
-}
-Helpers.inherits(ConnectionError, JanusError);
-
-module.exports.Error = JanusError;
-module.exports.ConnectionError = ConnectionError;
+module.exports = JanusError;

--- a/src/janus-message.js
+++ b/src/janus-message.js
@@ -14,7 +14,7 @@ JanusMessage.prototype.getPlainMessage = function() {
 };
 
 /**
- * @returns {*}
+ * @returns {Object}
  */
 JanusMessage.prototype.getError = function() {
   return this.get('error');

--- a/src/janus-plugin-message.js
+++ b/src/janus-plugin-message.js
@@ -25,10 +25,17 @@ JanusPluginMessage.prototype.getPluginData = function(name) {
 };
 
 /**
- * @returns {*}
+ * @returns {Object}
  */
 JanusPluginMessage.prototype.getError = function() {
-  return this.getPluginData('error') || JanusPluginMessage.super_.prototype.getError.call(this);
+  var error = this.getPluginData('error');
+  if (error) {
+    return {
+      reason: error,
+      code: this.getPluginData('error_code')
+    }
+  }
+  return JanusPluginMessage.super_.prototype.getError.call(this);
 };
 
 /**

--- a/src/janus-plugin-message.js
+++ b/src/janus-plugin-message.js
@@ -2,12 +2,12 @@ var Helpers = require('./helpers');
 var JanusMessage = require('./janus-message');
 
 /**
- * @param {JanusMessage} incomeMessage
+ * @param {Object} plainMessage
  * @param {Plugin} plugin
  * @constructor
  * @extends JanusMessage
  */
-function JanusPluginMessage(incomeMessage, plugin) {
+function JanusPluginMessage(plainMessage, plugin) {
   JanusPluginMessage.super_.apply(this, arguments);
   this._plugin = plugin;
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,6 +1,7 @@
 var Promise = require('bluebird');
 var Helpers = require('./helpers');
 var EventEmitter = require('./event-emitter');
+var JanusError = require('./error');
 var TTransactionGateway = require('./traits/t-transaction-gateway');
 var Transaction = require('./transaction');
 var JanusPluginMessage = require('./janus-plugin-message');
@@ -170,8 +171,7 @@ Plugin.prototype.sendWithTransaction = function(options) {
     if (!errorMessage) {
       return Promise.resolve(incomeMessage);
     }
-    var error = new Error(errorMessage);
-    error.response = incomeMessage;
+    var error = new JanusError.ConnectionError(incomeMessage);
     return Promise.reject(error);
   });
   var message = {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -114,33 +114,31 @@ Plugin.prototype.processOutcomeMessage = function(message) {
 /**
  * @param {JanusMessage} incomeMessage
  * @returns {Promise}
- * @fulfilled {JanusMessage} incomeMessage
  */
 Plugin.prototype.processIncomeMessage = function(incomeMessage) {
-  incomeMessage = new JanusPluginMessage(incomeMessage.getPlainMessage(), this);
-  var plugin = this;
+  var self = this;
   return Promise
     .try(function() {
+      incomeMessage = new JanusPluginMessage(incomeMessage.getPlainMessage(), self);
       if ('detached' === incomeMessage.get('janus')) {
-        return plugin._onDetached(incomeMessage);
+        return self._onDetached();
       }
-      return plugin.executeTransaction(incomeMessage)
-        .return(incomeMessage);
+      return self.defaultProcessIncomeMessage(incomeMessage);
     })
-    .then(function(message) {
-      plugin.emit('message', message);
-      return message;
-    });
+    .then(function() {
+      self.emit('message', incomeMessage);
+    })
+    .catch(function(error) {
+      self.emit('error', error);
+    })
 };
 
 /**
- * @param {JanusPluginMessage} incomeMessage
  * @returns {Promise}
- * @fulfilled {JanusPluginMessage} incomeMessage
  * @protected
  */
-Plugin.prototype._onDetached = function(incomeMessage) {
-  return this._detach().return(incomeMessage);
+Plugin.prototype._onDetached = function() {
+  return this._detach();
 };
 
 /**

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -171,7 +171,7 @@ Plugin.prototype.sendWithTransaction = function(options) {
     if (!errorMessage) {
       return Promise.resolve(incomeMessage);
     }
-    var error = new JanusError.ConnectionError(incomeMessage);
+    var error = new JanusError(incomeMessage);
     return Promise.reject(error);
   });
   var message = {

--- a/src/session.js
+++ b/src/session.js
@@ -197,7 +197,7 @@ Session.prototype._onAttach = function(outcomeMessage) {
         this.addPlugin(Plugin.create(this, outcomeMessage['plugin'], pluginId));
         return this.getPlugin(pluginId);
       } else {
-        throw new JanusError.ConnectionError(incomeMessage);
+        throw new JanusError(incomeMessage);
       }
     }.bind(this))
   );
@@ -225,7 +225,7 @@ Session.prototype._onDestroy = function(outcomeMessage) {
       if ('success' == incomeMessage.get('janus')) {
         return this._destroy().return(incomeMessage);
       } else {
-        throw new JanusError.ConnectionError(incomeMessage);
+        throw new JanusError(incomeMessage);
       }
     }.bind(this))
   );

--- a/src/session.js
+++ b/src/session.js
@@ -160,26 +160,27 @@ Session.prototype.processOutcomeMessage = function(message) {
  * @fulfilled {JanusMessage} incomeMessage
  */
 Session.prototype.processIncomeMessage = function(incomeMessage) {
+  var pluginId = incomeMessage.get('handle_id') || incomeMessage.get('sender');
+  if (pluginId && this.hasPlugin(pluginId)) {
+    return this.getPlugin(pluginId).processIncomeMessage(incomeMessage);
+  }
+
   var self = this;
   return Promise
     .try(function() {
+      if (pluginId && !self.hasPlugin(pluginId)) {
+        throw new Error('Invalid plugin [' + pluginId + ']');
+      }
       if ('timeout' === incomeMessage.get('janus')) {
         return self._onTimeout(incomeMessage);
       }
-      var pluginId = incomeMessage.get('handle_id') || incomeMessage.get('sender');
-      if (pluginId) {
-        if (self.hasPlugin(pluginId)) {
-          return self.getPlugin(pluginId).processIncomeMessage(incomeMessage);
-        } else {
-          return Promise.reject(new Error('Invalid plugin [' + pluginId + ']'));
-        }
-      }
-      return self.executeTransaction(incomeMessage)
-        .return(incomeMessage);
+      return self.defaultProcessIncomeMessage(incomeMessage);
     })
-    .then(function(message) {
-      self.emit('message', message);
-      return message;
+    .then(function() {
+      self.emit('message', incomeMessage);
+    })
+    .catch(function(error) {
+      self.emit('error', error);
     });
 };
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -1,5 +1,4 @@
 var Promise = require('bluebird');
-var error = require('./error');
 
 /**
  * @callback Transaction~callback
@@ -34,7 +33,7 @@ function Transaction(id, callback, timeoutPeriod) {
     };
 
     timeoutRejection = setTimeout(function() {
-      reject(new error.Error('Transaction timeout', 490));
+      reject(new Error('Transaction timeout ' + self.id));
     }, timeoutPeriod);
   });
   this._isExecuted = false;

--- a/src/webrtc/media-stream-plugin.js
+++ b/src/webrtc/media-stream-plugin.js
@@ -48,7 +48,7 @@ MediaStreamPlugin.prototype._watch = function(id, watchOptions, answerOptions) {
         throw new Error('Expect offer response on watch request')
       }
       plugin.setCurrentEntity(id);
-      return plugin._startMediaStreaming(jsep, answerOptions).return(response);
+      return plugin._offerAnswer(jsep, answerOptions).return(response);
     });
 };
 
@@ -126,7 +126,7 @@ MediaStreamPlugin.prototype.connect = function(id, watchOptions, answerOptions) 
  * @returns {Promise}
  * @fulfilled {JanusPluginMessage} response
  */
-MediaStreamPlugin.prototype._startMediaStreaming = function(jsep, answerOptions) {
+MediaStreamPlugin.prototype._offerAnswer = function(jsep, answerOptions) {
   var self = this;
   return Promise
     .try(function() {

--- a/src/webrtc/media-stream-plugin.js
+++ b/src/webrtc/media-stream-plugin.js
@@ -136,7 +136,7 @@ MediaStreamPlugin.prototype._startMediaStreaming = function(jsep, answerOptions)
       return self.createAnswer(jsep, answerOptions);
     })
     .then(function(jsep) {
-      return self.send({janus: 'message', body: {request: 'start'}, jsep: jsep});
+      return self.sendWithTransaction({janus: 'message', body: {request: 'start'}, jsep: jsep});
     });
 };
 

--- a/test/unit/connection.js
+++ b/test/unit/connection.js
@@ -97,16 +97,13 @@ describe('Connection tests', function() {
 
       it('delegates for existing session', function(done) {
         var messageToProcess = new JanusMessage({session_id: session.getId()});
-        sinon.stub(session, 'processIncomeMessage')
-          .withArgs(messageToProcess)
-          .returns(Promise.resolve('processed by session'));
+        sinon.stub(session, 'processIncomeMessage', function(incomeMessage) {
+          assert.equal(incomeMessage, messageToProcess);
+          done();
+          return Promise.resolve();
+        });
 
-        connection.processIncomeMessage(messageToProcess)
-          .then(function(result) {
-            assert.equal(result, 'processed by session');
-            done();
-          })
-          .catch(done);
+        connection.processIncomeMessage(messageToProcess).catch(done);
       });
 
       it('rejects for non existing session', function(done) {

--- a/test/unit/connection.js
+++ b/test/unit/connection.js
@@ -3,7 +3,7 @@ var sinon = require('sinon');
 var _ = require('underscore');
 var Promise = require('bluebird');
 var Transaction = require('../../src/transaction');
-var JanusError = require('../../src/error').Error;
+var JanusError = require('../../src/error');
 var Session = require('../../src/session');
 var Connection = require('../../src/connection');
 var JanusMessage = require('../../src/janus-message');
@@ -236,7 +236,11 @@ describe('Connection tests', function() {
         //just ignore it.
       });
       var incomeCreateSessionMessage = {
-        janus: 'error'
+        janus: 'error',
+        error: {
+          code: 0,
+          reason: ''
+        }
       };
       connection.createSession()
         .then(function() {

--- a/test/unit/plugin.js
+++ b/test/unit/plugin.js
@@ -98,7 +98,6 @@ describe('Plugin tests', function() {
       var message = new JanusMessage({janus: 'detached'});
       plugin.processIncomeMessage(message).then(function() {
         assert.isTrue(plugin._onDetached.calledOnce);
-        assert.equal(plugin._onDetached.getCall(0).args[0].getPlainMessage(), message.getPlainMessage());
         done();
       });
     });

--- a/test/unit/session.js
+++ b/test/unit/session.js
@@ -177,16 +177,13 @@ describe('Session tests', function() {
 
       it('resolves for existing plugin', function(done) {
         var messageToProcess = new JanusMessage({handle_id: plugin.getId()});
-        sinon.stub(plugin, 'processIncomeMessage')
-          .withArgs(messageToProcess)
-          .returns(Promise.resolve('processed by plugin'));
+        sinon.stub(plugin, 'processIncomeMessage', function(incomeMessage) {
+          assert.equal(incomeMessage, messageToProcess);
+          done();
+          return Promise.resolve();
+        });
 
-        session.processIncomeMessage(messageToProcess)
-          .then(function(result) {
-            assert.equal(result, 'processed by plugin');
-            done();
-          })
-          .catch(done);
+        session.processIncomeMessage(messageToProcess).catch(done);
       });
 
       it('rejects for non existing plugin', function(done) {

--- a/test/unit/session.js
+++ b/test/unit/session.js
@@ -312,12 +312,12 @@ describe('Session tests', function() {
         //catch error duplication
         transaction.promise.catch(_.noop);
 
-        transaction.execute(new JanusMessage({janus: 'error'}))
+        transaction.execute(new JanusMessage({janus: 'error', error: {code: 0, reason: ''}}))
           .then(function() {
             done(new Error('Plugin attach must be rejected'));
           })
           .catch(function(error) {
-            assert.instanceOf(error, JanusError.Error);
+            assert.instanceOf(error, JanusError);
             done();
           });
       });
@@ -354,12 +354,12 @@ describe('Session tests', function() {
         transaction.promise.catch(_.noop);
 
         sinon.stub(session, '_destroy');
-        transaction.execute(new JanusMessage({janus: 'error'}))
+        transaction.execute(new JanusMessage({janus: 'error', error: {code: 0, reason: ''}}))
           .then(function() {
             done(new Error('Session destroy must be rejected'));
           })
           .catch(function(error) {
-            assert.instanceOf(error, JanusError.Error);
+            assert.instanceOf(error, JanusError);
             assert.isFalse(session._destroy.called);
             done();
           });


### PR DESCRIPTION
Currently all errors emitted on Connection but messages are emitted on each instance they belong to. If message is on plugin level then it will be emitted on plugin, session, connection. If message is on session level then it will be emitted on session, connection. If message is on connection level then it will be emitted on connection only. On the other hand errors are emitted on connection only. Shall we emit plugin errors on plugin? session errors on session? and have the same mechanism as we have now with messages?
Shall we change this mechanism in the way that plugin messages will be emitted only on plugin and don't go further and be emitted on session and connection?

@zazabe 